### PR TITLE
Changed the default dir for factory_girl factories

### DIFF
--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -4,7 +4,7 @@ module FactoryGirl
   module Generators
     class ModelGenerator < Base
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
-      class_option :dir, :type => :string, :default => "test/factories", :desc => "The directory where the factories should go"
+      class_option :dir, :type => :string, :default => "spec/factories", :desc => "The directory where the factories should go"
       
       def create_fixture_file
         template 'fixtures.rb', File.join(options[:dir], "#{table_name}.rb")


### PR DESCRIPTION
Since the default dir for RSpec is 'spec/', it seems a good idea to define default dir for factories to 'spec/factories'.

Regards.
