### PR TITLE
Added active_model generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails3-generators (0.16.0.beta)
+    rails3-generators (0.16.0)
       rails (>= 3.0.0)
 
 GEM

--- a/lib/generators/active_model.rb
+++ b/lib/generators/active_model.rb
@@ -1,0 +1,32 @@
+require 'rails/generators/named_base'
+require 'rails/generators/migration'
+require 'rails/generators/active_model'
+
+require 'generators/helpers/migration_helper'
+
+module ActiveModel
+  module Generators
+    class Base < Rails::Generators::NamedBase #:nodoc:
+
+      def self.source_root
+        @_activemodel_source_root ||= File.expand_path(File.join(File.dirname(__FILE__),
+                                                      'active_model', generator_name, 'templates'))
+      end
+
+    end
+
+    class ActiveModel < Rails::Generators::ActiveModel #:nodoc:
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class GeneratedAttribute #:nodoc:
+      def type_class
+        return 'DateTime' if type.to_s == 'datetime'
+        return type.to_s.camelcase
+      end
+    end
+  end
+end

--- a/lib/generators/active_model/model/model_generator.rb
+++ b/lib/generators/active_model/model/model_generator.rb
@@ -1,0 +1,41 @@
+require 'generators/active_model'
+
+module ActiveModel
+  module Generators
+    class ModelGenerator < Base
+      argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
+
+      check_class_collision
+
+      def create_model_file
+        template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")
+      end
+      
+      def read_properties?
+        attributes.any?{|attr| attr.type == :read }
+      end
+
+      def read_properties
+        attributes.select{|attr| attr.type == :read}.map{|attr| ":#{attr.name}" }.join(",")
+      end
+
+      def write_properties?
+        attributes.any?{|attr| attr.type == :write }
+      end
+
+      def write_properties
+        attributes.select{|attr| attr.type == :write }.map{|attr| ":#{attr.name}" }.join(",")
+      end
+
+      def accessor_properties?
+        attributes.any?{|attr| attr.type == :all }
+      end
+
+      def accessor_properties
+        attributes.select{|attr| attr.type == :all }.map{|attr| ":#{attr.name}" }.join(",")
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/lib/generators/active_model/model/templates/model.rb
+++ b/lib/generators/active_model/model/templates/model.rb
@@ -1,7 +1,7 @@
 class <%= class_name %>
   include ActiveModel::Serialization
   include ActiveModel::Validations
-<%= attributes %>
+
   <% if read_properties? %>
     attr_reader <%= read_properties %>
   <% end %>

--- a/lib/generators/active_model/model/templates/model.rb
+++ b/lib/generators/active_model/model/templates/model.rb
@@ -1,15 +1,13 @@
 class <%= class_name %>
   include ActiveModel::Serialization
   include ActiveModel::Validations
-
-  <% if read_properties? %>
-    attr_reader <%= read_properties %>
-  <% end %>
-  <% if write_properties? %>
-    attr_writer <%= write_properties %>
-  <% end %>
-  <% if accessor_properties? %>
-    attr_accessor <%= accessor_properties %>
-  <% end %>
-
+<% if read_properties? %>
+  attr_reader <%= read_properties %>
+<% end %>
+<% if write_properties? %>
+  attr_writer <%= write_properties %>
+<% end %>
+<% if accessor_properties? %>
+  attr_accessor <%= accessor_properties %>
+<% end %>
 end

--- a/lib/generators/active_model/model/templates/model.rb
+++ b/lib/generators/active_model/model/templates/model.rb
@@ -1,0 +1,15 @@
+class <%= class_name %>
+  include ActiveModel::Serialization
+  include ActiveModel::Validations
+<%= attributes %>
+  <% if read_properties? %>
+    attr_reader <%= read_properties %>
+  <% end %>
+  <% if write_properties? %>
+    attr_writer <%= write_properties %>
+  <% end %>
+  <% if accessor_properties? %>
+    attr_accessor <%= accessor_properties %>
+  <% end %>
+
+end

--- a/lib/rails3-generators.rb
+++ b/lib/rails3-generators.rb
@@ -5,7 +5,7 @@ end
 
 Rails::Generators.hidden_namespaces << "rails"
 
-%w(active_record data_mapper mongo_mapper mongoid).each do |orm|
+%w(active_record data_mapper mongo_mapper mongoid active_model).each do |orm|
   Rails::Generators.hidden_namespaces <<
   [
     "#{orm}:migration",

--- a/test/lib/generators/active_model/model_generator_test.rb
+++ b/test/lib/generators/active_model/model_generator_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require_generator :active_model  => ['model']
+
+class ActiveModel::Generators::ModelGeneratorTest < Rails::Generators::TestCase
+  destination File.join(Rails.root)
+  tests ActiveModel::Generators::ModelGenerator
+
+  setup :prepare_destination
+  setup :copy_routes
+
+  test "invoke with model name" do
+    content = run_generator %w(Account)
+
+    assert_file "app/models/account.rb" do |account|
+      assert_class "Account", account do |klass|
+        assert_match /include ActiveModel::Validations/, klass
+        assert_match /include ActiveModel::Serialization/, klass
+      end
+    end
+  end
+
+  test "invoke with model name and accessors" do
+    content = run_generator %w(Account name:all age:read color:write )
+
+    assert_file "app/models/account.rb" do |account|
+      assert_class "Account", account do |klass|
+        assert_match /include ActiveModel::Validations/, klass
+        assert_match /include ActiveModel::Serialization/, klass
+        assert_match /attr_reader :age/, klass
+        assert_match /attr_writer :color/, klass        
+        assert_match /attr_accessor :name/, klass        
+      end
+    end
+  end  
+end


### PR DESCRIPTION
I've added a generator for creating models with no persistent.
They still include ActiveModel:Validations and ActiveModel:Serialization.

When generating properties you can use the following as types to create the required accessor

read - generate read_accessor
write - generate write_accessor
all - generate attr_accessor
