### PR TITLE
Bugfix for MongoMapper

### DIFF
--- a/lib/generators/mongo_mapper.rb
+++ b/lib/generators/mongo_mapper.rb
@@ -17,7 +17,7 @@ module MongoMapper
       end
 
       def self.find(klass, params=nil)
-        "#{klass}.first(#{params})"
+        "#{klass}.find(#{params})"
       end
 
       def self.build(klass, params=nil)


### PR DESCRIPTION
Generated controller throws an exception due to wrong find method.
