### PR TITLE
Added a generator for scaffolds to the shoulda generator

### DIFF
--- a/lib/generators/shoulda/scaffold/scaffold_generator.rb
+++ b/lib/generators/shoulda/scaffold/scaffold_generator.rb
@@ -1,0 +1,15 @@
+require 'generators/shoulda'
+
+module Shoulda
+  module Generators
+    class ScaffoldGenerator < Base
+      include Rails::Generators::ResourceHelpers
+
+      check_class_collision :suffix => 'ControllerTest'
+
+      def create_controller_file
+        template 'scaffold.rb', File.join('test/functional', controller_class_path, "#{controller_file_name}_controller_test.rb")
+      end
+    end
+  end
+end

--- a/lib/generators/shoulda/scaffold/templates/scaffold.rb
+++ b/lib/generators/shoulda/scaffold/templates/scaffold.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class <%= controller_class_name %>ControllerTest < ActionController::TestCase
+  
+  context "index action" do
+    should "render index template" do
+      get :index
+      assert_template 'index'
+    end
+  end
+
+  context "show action" do
+    should "render show template" do
+      get :show, :id => <%= class_name %>.first
+      assert_template 'show'
+    end
+  end    
+  
+  context "new action" do
+    should "render new template" do
+      get :new
+      assert_template 'new'
+    end
+  end
+
+  context "create action" do
+    should "render new template when model is invalid" do
+      <%= class_name %>.any_instance.stubs(:valid?).returns(false)
+      post :create
+      assert_template 'new'
+    end
+    
+    should "redirect when model is valid" do
+      <%= class_name %>.any_instance.stubs(:valid?).returns(true)
+      post :create
+      assert_redirected_to
+    end
+  end
+
+  context "edit action" do
+    should "render edit template" do
+      get :edit, :id => <%= class_name %>.first
+      assert_template 'edit'
+    end
+  end
+
+  context "update action" do
+    should "render edit template when model is invalid" do
+      <%= class_name %>.any_instance.stubs(:valid?).returns(false)
+      put :update, :id => <%= class_name %>.first
+      assert_template 'edit'
+    end
+  
+    should "redirect when model is valid" do
+      <%= class_name %>.any_instance.stubs(:valid?).returns(true)
+      put :update, :id => <%= class_name %>.first
+      assert_redirected_to
+    end
+  end
+
+  context "destroy action" do
+    should "destroy model and redirect to index action" do
+      <%= singular_name %> = <%= class_name %>.first
+      delete :destroy, :id => <%= singular_name %>
+      assert_redirected_to
+      assert !<%= class_name %>.exists?(<%= singular_name %>.id)
+    end
+  end
+  
+end

--- a/test/lib/generators/shoulda/scaffold_generator_test.rb
+++ b/test/lib/generators/shoulda/scaffold_generator_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Shoulda::Generators::ScaffoldGeneratorTest < Rails::Generators::TestCase
+  destination File.join(Rails.root)
+  tests Rails::Generators::ScaffoldGenerator
+  arguments %w(accounts --test-framework shoulda)
+
+  setup :prepare_destination
+  setup :copy_routes
+
+  test "should invoke test framework" do
+    run_generator
+    assert_file "test/functional/accounts_controller_test.rb"
+  end
+
+  test "should create test class" do
+    run_generator
+    assert_file "test/functional/accounts_controller_test.rb" do |controller_test|
+      assert_class "AccountsControllerTest", controller_test
+    end
+  end
+
+  test "should create controller action tests" do
+    run_generator
+    assert_file "test/functional/accounts_controller_test.rb" do |controller_test|
+      assert_class "AccountsControllerTest", controller_test do |klass|
+        assert_match /context "index action"/, klass
+        assert_match /context "show action"/, klass
+        assert_match /context "new action"/, klass
+        assert_match /context "create action"/, klass
+        assert_match /context "edit action"/, klass
+        assert_match /context "update action"/, klass
+        assert_match /context "destroy action"/, klass
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,7 +54,7 @@ def generator_list
     :factory_girl => ['model'],
     :authlogic    => ['session'],
     :koala        => ['install'],
-    :shoulda      => ['controller']
+    :shoulda      => ['controller', 'scaffold']
   }
 end
 


### PR DESCRIPTION
I added a generator for a scaffold to the shoulda generator. When you were generating a scaffold in rails, the shoulda tests for the controller were not generated. He was complaining that that generator did not exist. After some digging I discovered it was due to the fact that it not using the controller generator, but a scaffold generator. I added that one, now everything works as expected.
For the generator file itself I used the one that was previously defined as the controller generator, to keep it in line with the already present one.
