### PR TITLE
Replace RAILS_ROOT and RAILS_ENV constants with Rails.root and Rails.env

### DIFF
--- a/lib/generators/koala/install/templates/config/initializers/koala.rb.tt
+++ b/lib/generators/koala/install/templates/config/initializers/koala.rb.tt
@@ -3,7 +3,7 @@
 # automatically use Facebook settings from here if none are given
 
 module Facebook
-  CONFIG = YAML.load(ERB.new(File.read("#{RAILS_ROOT}/config/facebook.yml")).result)[RAILS_ENV]
+  CONFIG = YAML.load(ERB.new(File.read("#{Rails.root}/config/facebook.yml")).result)[Rails.env]
   APP_ID = CONFIG['app_id']
   SECRET = CONFIG['secret_key']
 end


### PR DESCRIPTION
Since Rails 3.1 RAILS_ROOT and RAILS_ENV are no longer defined.
I've search for occurrences of these variables and replaced them.
